### PR TITLE
Add ability to set X-Gtm-Server-Preview HTTP header

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,9 @@
 on: [pull_request]
 
+permissions:
+  checks: write
+  pull-requests: write
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Fill in the basic parameters:
 import StapeSGTM, { transformations, EventData } from 'stape-sgtm-nodejs';
 
 const sgtm = new StapeSGTM({
-   gtm_server_domain: 'https://gtm.stape.io',
-   request_path: '/data',
+  gtm_server_domain: 'https://gtm.stape.io',
+  request_path: '/data',
  });
 ```
 
@@ -66,6 +66,7 @@ import StapeSGTM, { transformations, EventData } from 'stape-sgtm-nodejs';
 const sgtm = new StapeSGTM({
   gtm_server_domain: 'https://gtm.stape.io',
   request_path: '/data',
+  preview_header: 'ZW52LTV8VTc5TlhtZkx3SHpIU004bEpyQWtRZ3wxOTRlMjZlOGJjZTViNTQ2OWI3NzM=',
 });
 
 const eventData: EventData = {

--- a/example/index.ts
+++ b/example/index.ts
@@ -3,6 +3,8 @@ import StapeSGTM, { transformations, EventData } from 'stape-sgtm-nodejs';
 const sgtm = new StapeSGTM({
   gtm_server_domain: 'https://gtm.stape.io',
   request_path: '/data',
+  preview_header:
+    'ZW52LTV8VTc5TlhtZkx3SHpIU004bEpyQWtRZ3wxOTRlMjZlOGJjZTViNTQ2OWI3NzM=',
 });
 
 const eventData: EventData = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stape-sgtm-nodejs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "Apache-2.0",
   "author": "stape-io",
   "description": "NodeJS SDK for stape",

--- a/src/StapeSGTM.test.ts
+++ b/src/StapeSGTM.test.ts
@@ -22,7 +22,7 @@ describe('StapeSGTM', () => {
   });
 
   it('should send event data and return the response data', async () => {
-    const instance = createTestInstance();
+    const instance = createTestInstance({ preview_header: 'preview_header' });
 
     (axios.post as jest.Mock).mockResolvedValueOnce({ data: 'response data' });
 
@@ -36,6 +36,11 @@ describe('StapeSGTM', () => {
         ...eventData,
         event_name: 'event',
         v: 2,
+      },
+      {
+        headers: {
+          'X-Gtm-Server-Preview': 'preview_header',
+        },
       },
     );
   });
@@ -55,6 +60,9 @@ describe('StapeSGTM', () => {
         event_name: 'event',
         v: 2,
       },
+      {
+        headers: {},
+      },
     );
   });
 
@@ -70,6 +78,7 @@ describe('StapeSGTM', () => {
         event_name: 'event',
         v: 2,
       },
+      { headers: {} },
     );
   });
 

--- a/src/StapeSGTM.ts
+++ b/src/StapeSGTM.ts
@@ -12,12 +12,14 @@ export class StapeSGTM {
     request_path = '/data',
     richsstsse = false,
     protocol_version = 2,
+    preview_header = '',
   }: StapeSGTMOptions) {
     this.config = {
       gtm_server_domain,
       request_path,
       richsstsse,
       protocol_version,
+      preview_header,
     };
     this.validateConfig();
   }
@@ -44,7 +46,14 @@ export class StapeSGTM {
         v: this.config.protocol_version,
       };
 
-      const response = await axios.post<R>(url.toString(), postData);
+      let headers: HeadersInit = {};
+      if (this.config.preview_header) {
+        headers['X-Gtm-Server-Preview'] = this.config.preview_header;
+      }
+
+      const response = await axios.post<R>(url.toString(), postData, {
+        headers,
+      });
       return response.data;
     } catch (error) {
       const response = (error as AxiosError).response;

--- a/src/types/StapeSGTMOptions.ts
+++ b/src/types/StapeSGTMOptions.ts
@@ -3,4 +3,5 @@ export type StapeSGTMOptions = {
   request_path?: string;
   protocol_version?: number;
   richsstsse?: boolean;
+  preview_header?: string;
 };


### PR DESCRIPTION
Add support for setting the `X-Gtm-Server-Preview` HTTP header for local development.

* Add the `preview_header` parameter to the `StapeSGTMOptions` type in `src/types/StapeSGTMOptions.ts`.
* Update the `StapeSGTM` constructor in `src/StapeSGTM.ts` to accept the `preview_header` parameter and set it in the config.
* Modify the `sendEventData` method in `src/StapeSGTM.ts` to include the `X-Gtm-Server-Preview` HTTP header if `preview_header` is provided.
* Update the example in `example/index.ts` to demonstrate setting the `X-Gtm-Server-Preview` HTTP header.
* Update the `README.md` to include documentation for the `preview_header` option.

Closes #8 

